### PR TITLE
feat: pass mongoClient as a second argument to migrations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,10 +67,10 @@ export class Migration {
    * @param db
    */
   private async runMigration(migration: MigrationFile, db: Db) {
-    await migration.up(db).catch(async e => {
+    await migration.up(db, this.client).catch(async e => {
       console.error("failed up migration:", migration.name, e);
       if (migration.down) {
-        await migration.down(db).catch(e => {
+        await migration.down(db, this.client).catch(e => {
           console.error("failed down migration:", migration.name, e);
         });
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
-import { Db } from "mongodb";
+import { Db, MongoClient } from "mongodb";
 
 export type MigrationFile = {
   // unique name of migration file
   name: string;
   // method to be run if the previous one succeeds
-  up: (db: Db) => Promise<void>;
+  up: (db: Db, client?: MongoClient) => Promise<void>;
   // method to be run if the current one failed
-  down?: (db: Db) => Promise<void>;
+  down?: (db: Db, client?: MongoClient) => Promise<void>;
 };
 
 export type MigrationOptions = {


### PR DESCRIPTION
this allows using migrations to update data in databases different to the one tracking migration progress